### PR TITLE
Feature - credential entry

### DIFF
--- a/test-01.ipynb
+++ b/test-01.ipynb
@@ -1,6 +1,16 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Bok-ATG/huit-at-test/blob/feature%2FcredentialEntry/test-01.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -301,7 +311,8 @@
       "version": "3.11.1"
     },
     "colab": {
-      "provenance": []
+      "provenance": [],
+      "include_colab_link": true
     }
   },
   "nbformat": 4,

--- a/test-01.ipynb
+++ b/test-01.ipynb
@@ -1,309 +1,309 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JS_2Zqm4qQJ9"
+      },
+      "outputs": [],
+      "source": [
+        "import json, textwrap"
+      ]
     },
-    "id": "MHx9HLC5ek47",
-    "outputId": "eebc9c7c-29f4-4de4-ceab-c4b8373ef7dc"
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "IN_COLAB = 'google.colab' in sys.modules\n",
-    "IN_COLAB"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Collect credentials"
+      ],
+      "metadata": {
+        "id": "boXaVophqiZD"
+      }
     },
-    "id": "VArthakWe1zK",
-    "outputId": "5412ebf8-7716-48a1-c258-53e7198c92aa"
-   },
-   "outputs": [],
-   "source": [
-    "if IN_COLAB:\n",
-    "  !pip install python-dotenv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "z_wX1WwxeNF9"
-   },
-   "outputs": [],
-   "source": [
-    "from dotenv import load_dotenv, find_dotenv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "EfDZtPpFeNGA"
-   },
-   "outputs": [],
-   "source": [
-    "import json, textwrap"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "from getpass import getpass"
+      ],
+      "metadata": {
+        "id": "6q_UsN_bqxx7"
+      },
+      "execution_count": null,
+      "outputs": []
     },
-    "id": "41K0A5tleNGB",
-    "outputId": "5892e2bf-0e89-4906-cc10-334c41ddf224"
-   },
-   "outputs": [],
-   "source": [
-    "load_dotenv('huit-at-test/.env')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qyTWJpB5eNGB"
-   },
-   "outputs": [],
-   "source": [
-    "import os"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "code",
+      "source": [
+        "# Check if running in Google Colab\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    IS_COLAB = True\n",
+        "    print(\"Running in Google Colab environment\")\n",
+        "except ImportError:\n",
+        "    IS_COLAB = False\n",
+        "    print(\"Running in local environment\")\n",
+        "\n",
+        "# Initialize variables\n",
+        "OPENAI_KEY = None\n",
+        "OPENAI_SECRET = None\n",
+        "credentials_entered_manually = False\n",
+        "\n",
+        "# Method 1: Try loading from .env file\n",
+        "try:\n",
+        "    from dotenv import load_dotenv\n",
+        "    load_dotenv()\n",
+        "    OPENAI_KEY = os.getenv('OPENAI_KEY')\n",
+        "    OPENAI_SECRET = os.getenv('OPENAI_SECRET')\n",
+        "    if OPENAI_KEY and OPENAI_SECRET:\n",
+        "        print(\"✓ Credentials loaded from .env file\")\n",
+        "    else:\n",
+        "        raise ValueError(\"Credentials not found in .env file\")\n",
+        "except (ImportError, ValueError):\n",
+        "    # Method 2: Try Google Colab secrets (only if in Colab)\n",
+        "    if IS_COLAB:\n",
+        "        try:\n",
+        "            OPENAI_KEY = userdata.get('OPENAI_KEY')\n",
+        "            OPENAI_SECRET = userdata.get('OPENAI_SECRET')\n",
+        "            print(\"✓ Credentials loaded from Google Colab secrets\")\n",
+        "        except Exception:\n",
+        "            # Method 3: Get credentials via user input\n",
+        "            print(\"Credentials not found in Colab secrets.\")\n",
+        "    else:\n",
+        "        # Method 3: Get credentials via user input (local environment)\n",
+        "        print(\"Credentials not found in .env file.\")\n",
+        "    if not OPENAI_KEY and not OPENAI_SECRET:\n",
+        "      print(\"Please enter your OpenAI credentials:\")\n",
+        "      OPENAI_KEY = getpass(\"Enter your OpenAI API Key: \")\n",
+        "      OPENAI_SECRET = getpass(\"Enter your OpenAI Secret: \")\n",
+        "      credentials_entered_manually = True\n",
+        "      print(\"✓ Credentials entered manually\")\n",
+        "\n",
+        "# Verify credentials were obtained\n",
+        "if not OPENAI_KEY or not OPENAI_SECRET:\n",
+        "    raise ValueError(\"Failed to obtain OpenAI credentials\")\n",
+        "\n",
+        "# Save credentials if they were entered manually\n",
+        "if credentials_entered_manually:\n",
+        "    if IS_COLAB:\n",
+        "        print(\"\\n\" + \"=\"*60)\n",
+        "        print(\"TO SAVE CREDENTIALS FOR FUTURE USE:\")\n",
+        "        print(\"1. Click the 🔑 key icon in the left sidebar\")\n",
+        "        print(\"2. Add a new secret with name: OPENAI_KEY\")\n",
+        "        print(\"3. Add a new secret with name: OPENAI_SECRET\")\n",
+        "        print(\"4. Paste your respective values and enable 'Notebook access'\")\n",
+        "        print(\"=\"*60)\n",
+        "    else:\n",
+        "        # Save to .env file\n",
+        "        try:\n",
+        "            with open('.env', 'a') as f:\n",
+        "                # Check if file is empty or doesn't end with newline\n",
+        "                f.seek(0, 2)  # Go to end of file\n",
+        "                if f.tell() > 0:  # File is not empty\n",
+        "                    f.seek(-1, 2)  # Go to last character\n",
+        "                    if f.read(1) != '\\n':\n",
+        "                        f.write('\\n')\n",
+        "\n",
+        "                f.write(f\"OPENAI_KEY={OPENAI_KEY}\\n\")\n",
+        "                f.write(f\"OPENAI_SECRET={OPENAI_SECRET}\\n\")\n",
+        "            print(\"✓ Credentials saved to .env file for future use\")\n",
+        "        except Exception as e:\n",
+        "            print(f\"⚠ Could not save to .env file: {e}\")\n",
+        "\n",
+        "print(\"Credentials successfully loaded and ready to use!\")"
+      ],
+      "metadata": {
+        "id": "4bzLLlBIqWJ3"
+      },
+      "execution_count": null,
+      "outputs": []
     },
-    "id": "VdEKgg-8f3Zo",
-    "outputId": "674aab74-91a4-4f1c-bb74-58e1ea50a0d8"
-   },
-   "outputs": [],
-   "source": [
-    "# if IN_COLAB:\n",
-    "#   from google.colab import userdata\n",
-    "#   os.environ['OPENAI_KEY'] = userdata.get('OPENAI_KEY')\n",
-    "#   os.environ['OPENAI_SECRET'] = userdata.get('OPENAI_SECRET')\n",
-    "if IN_COLAB:\n",
-    "  from getpass import getpass\n",
-    "  OPENAI_KEY = getpass(\"OPENAI_KEY\")\n",
-    "  OPENAI_SECRET = getpass(\"OPENAI_SECRET\")\n",
-    "else:\n",
-    "  OPENAI_KEY = os.getenv('OPENAI_KEY')\n",
-    "  OPENAI_SECRET = os.getenv('OPENAI_SECRET')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "f-IOpTNceNGD"
-   },
-   "outputs": [],
-   "source": [
-    "harvard_api = 'https://go.apis.huit.harvard.edu/ais-openai-direct-limited-schools/v1'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ujMhp8soeNGD"
-   },
-   "outputs": [],
-   "source": [
-    "from openai import OpenAI, BaseModel\n",
-    "client = OpenAI(\n",
-    "    api_key=OPENAI_KEY,\n",
-    "    base_url=harvard_api\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "xMBHECmfeNGE"
-   },
-   "outputs": [],
-   "source": [
-    "raw_text = \"\"\"\n",
-    "Of Man’s first disobedience, and the fruit\n",
-    "Of that forbidden tree whose mortal taste\n",
-    "Brought death into the World, and all our woe,\n",
-    "With loss of Eden, till one greater Man\n",
-    "Restore us, and regain the blissful seat,\n",
-    "Sing Heavenly Muse, that, on the secret top\n",
-    "Of Oreb or of Sinai, didst inspire\n",
-    "That shepherd who first taught the chosen seed,\n",
-    "In the beginning how the heavens and earth\n",
-    "Rose out of Chaos: or if Sion Hill\n",
-    "Delight thee more, and Siloa’s brook that flow’d\n",
-    "Fast by the oracle of God; I thence\n",
-    "Invoke thy aid to my advent’rous song,\n",
-    "That with no middle flight intends to soar\n",
-    "Above th’ Aonian mount, while it pursues\n",
-    "Things unattempted yet in prose or rhyme.\n",
-    "\"\"\"\n",
-    "\n",
-    "class PLExcerpt(BaseModel):\n",
-    "    book: int\n",
-    "    lines: str\n",
-    "    characters: list[str]\n",
-    "    themes: list[str]\n",
-    "    summary: str\n",
-    "\n",
-    "    model_config = {\"extra\": \"forbid\"}\n",
-    "\n",
-    "schema = PLExcerpt.model_json_schema()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "L_NaZS1uqQJ9"
+      },
+      "outputs": [],
+      "source": [
+        "harvard_api = 'https://go.apis.huit.harvard.edu/ais-openai-direct-limited-schools/v1'"
+      ]
     },
-    "id": "bNut6o9KeNGF",
-    "outputId": "ced32838-c251-417d-8139-91dae8d4c071"
-   },
-   "outputs": [],
-   "source": [
-    "response = client.responses.create(\n",
-    "    model=\"gpt-4o-2024-08-06\",\n",
-    "    input=[\n",
-    "        {\n",
-    "            \"role\": \"system\",\n",
-    "            \"content\": \"Extract structured data about the passage. Make sure the summary is concise and technical, fitting for an academic well-versed in the text. Remove any filler or aggrandizement.\"\n",
-    "                       \"Return JSON only—no extra keys or text.\"\n",
-    "        },\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": raw_text\n",
-    "        },\n",
-    "    ],\n",
-    "    text={\n",
-    "        \"format\": {\n",
-    "            \"type\": \"json_schema\",\n",
-    "            \"name\": \"paradise_lost_excerpt\",\n",
-    "            \"strict\": True,\n",
-    "            \"schema\": schema,\n",
-    "        }\n",
-    "    },\n",
-    ")\n",
-    "\n",
-    "print(\"Parsed object:\\n\")\n",
-    "\n",
-    "parsed = json.loads(response.output_text)\n",
-    "parsed[\"summary\"] = textwrap.fill(parsed[\"summary\"], width=80)\n",
-    "print(json.dumps(parsed, indent=2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "-3wfYXYpeNGG"
-   },
-   "outputs": [],
-   "source": [
-    "import requests"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "fxFs8Qm1eNGG"
-   },
-   "outputs": [],
-   "source": [
-    "client.api_base = harvard_api"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "B2iYYIPQqQJ-"
+      },
+      "outputs": [],
+      "source": [
+        "from openai import OpenAI, BaseModel\n",
+        "client = OpenAI(\n",
+        "    api_key=OPENAI_KEY,\n",
+        "    base_url=harvard_api\n",
+        ")"
+      ]
     },
-    "id": "dESsrvfxeNGH",
-    "outputId": "25426709-2a04-4292-e0cc-57f6b1288963"
-   },
-   "outputs": [],
-   "source": [
-    "url = \"https://go.apis.huit.harvard.edu/ais-openai-direct-limited-schools/v1/chat/completions\"\n",
-    "payload = json.dumps({\n",
-    "  \"model\": \"gpt-4o-mini\",\n",
-    "  \"messages\": [\n",
-    "    {\n",
-    "      \"role\": \"user\",\n",
-    "      \"content\": \"To what extent does scientific conservatism limit new discoveries?\"\n",
-    "    }\n",
-    "  ],\n",
-    "  \"temperature\": 0.7\n",
-    "})\n",
-    "headers = {\n",
-    "  'Content-Type': 'application/json',\n",
-    "  'api-key': OPENAI_KEY\n",
-    "}\n",
-    "response = requests.request(\"POST\", url, headers=headers, data=payload)\n",
-    "print(response.text)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JyBwzEV9qQJ-"
+      },
+      "outputs": [],
+      "source": [
+        "raw_text = \"\"\"\n",
+        "Of Man’s first disobedience, and the fruit\n",
+        "Of that forbidden tree whose mortal taste\n",
+        "Brought death into the World, and all our woe,\n",
+        "With loss of Eden, till one greater Man\n",
+        "Restore us, and regain the blissful seat,\n",
+        "Sing Heavenly Muse, that, on the secret top\n",
+        "Of Oreb or of Sinai, didst inspire\n",
+        "That shepherd who first taught the chosen seed,\n",
+        "In the beginning how the heavens and earth\n",
+        "Rose out of Chaos: or if Sion Hill\n",
+        "Delight thee more, and Siloa’s brook that flow’d\n",
+        "Fast by the oracle of God; I thence\n",
+        "Invoke thy aid to my advent’rous song,\n",
+        "That with no middle flight intends to soar\n",
+        "Above th’ Aonian mount, while it pursues\n",
+        "Things unattempted yet in prose or rhyme.\n",
+        "\"\"\"\n",
+        "\n",
+        "class PLExcerpt(BaseModel):\n",
+        "    book: int\n",
+        "    lines: str\n",
+        "    characters: list[str]\n",
+        "    themes: list[str]\n",
+        "    summary: str\n",
+        "\n",
+        "    model_config = {\"extra\": \"forbid\"}\n",
+        "\n",
+        "schema = PLExcerpt.model_json_schema()"
+      ]
     },
-    "id": "4XoqUcObeNGH",
-    "outputId": "b26acdc0-55a0-42f0-b88f-8b18205a9a00"
-   },
-   "outputs": [],
-   "source": [
-    "response.json()"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "provenance": []
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Ujp8K8t-qQJ-"
+      },
+      "outputs": [],
+      "source": [
+        "response = client.responses.create(\n",
+        "    model=\"gpt-4o-2024-08-06\",\n",
+        "    input=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"Extract structured data about the passage. Make sure the summary is concise and technical, fitting for an academic well-versed in the text. Remove any filler or aggrandizement.\"\n",
+        "                       \"Return JSON only—no extra keys or text.\"\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": raw_text\n",
+        "        },\n",
+        "    ],\n",
+        "    text={\n",
+        "        \"format\": {\n",
+        "            \"type\": \"json_schema\",\n",
+        "            \"name\": \"paradise_lost_excerpt\",\n",
+        "            \"strict\": True,\n",
+        "            \"schema\": schema,\n",
+        "        }\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(\"Parsed object:\\n\")\n",
+        "\n",
+        "parsed = json.loads(response.output_text)\n",
+        "parsed[\"summary\"] = textwrap.fill(parsed[\"summary\"], width=80)\n",
+        "print(json.dumps(parsed, indent=2))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7yFmBNWhqQJ_"
+      },
+      "outputs": [],
+      "source": [
+        "import requests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fDcLc_5yqQJ_"
+      },
+      "outputs": [],
+      "source": [
+        "client.api_base = harvard_api"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Kf399yUVqQJ_"
+      },
+      "outputs": [],
+      "source": [
+        "url = \"https://go.apis.huit.harvard.edu/ais-openai-direct-limited-schools/v1/chat/completions\"\n",
+        "payload = json.dumps({\n",
+        "  \"model\": \"gpt-4o-mini\",\n",
+        "  \"messages\": [\n",
+        "    {\n",
+        "      \"role\": \"user\",\n",
+        "      \"content\": \"To what extent does scientific conservatism limit new discoveries?\"\n",
+        "    }\n",
+        "  ],\n",
+        "  \"temperature\": 0.7\n",
+        "})\n",
+        "headers = {\n",
+        "  'Content-Type': 'application/json',\n",
+        "  'api-key': OPENAI_KEY\n",
+        "}\n",
+        "response = requests.request(\"POST\", url, headers=headers, data=payload)\n",
+        "print(response.text)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "IjvKoqVyqQJ_"
+      },
+      "outputs": [],
+      "source": [
+        "response.json()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.1"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.1"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
With directed help from Claude 4 Sonnet, I created a setup to load OpenAI credentials from a dotenv file, then try Colab's secrets manager, then prompt the user for manual entry if both of those fails. If the user had to enter the credentials manually, either save a dotenv file in the script or tell the user how to save the credentials in Colab (since Colab doesn't provide a programmatic way to do this).